### PR TITLE
Chore/local run improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,31 +55,7 @@ Open http://localhost:3000 to see the app.
 
 
 > if necessary to install Ruby, we use Ruby 2.7.2:
-```
-sudo apt update
-sudo apt install -y curl gnupg2 build-essential libssl-dev libreadline-dev zlib1g-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev git
 
-# Install rbenv and ruby-build
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer | bash
-
-# Add rbenv to bash so it loads every time
-echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-echo 'eval "$(rbenv init - bash)"' >> ~/.bashrc
-source ~/.bashrc
-
-# Install Ruby 2.7.2
-rbenv install 2.7.2
-
-# Check the version
-ruby -v
-
-# Install bundler
-gem install bundler -v 2.4.22
-
-
-# Proceed with 'bundle' command
-bundle
-```
 ## Deployment
 
 The app is hosted on S3, with Cloudfront for a CDN.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ To run this project locally, install the dependencies and run the local server:
 ```shell
 yarn
 bundle # JSON parsing takes a while to run using JS when indexing, so we're using Ruby just for indexing
+```
 
+In a separate shell, run typesense server:
+```bash
+# Bellow command needs docker installed
 yarn run typesenseServer
+```
+
+```bash
 
 ln -s .env.development .env
 
@@ -46,6 +53,33 @@ yarn start
 
 Open http://localhost:3000 to see the app.
 
+
+> if necessary to install Ruby, we use Ruby 2.7.2:
+```
+sudo apt update
+sudo apt install -y curl gnupg2 build-essential libssl-dev libreadline-dev zlib1g-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev git
+
+# Install rbenv and ruby-build
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer | bash
+
+# Add rbenv to bash so it loads every time
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(rbenv init - bash)"' >> ~/.bashrc
+source ~/.bashrc
+
+# Install Ruby 2.7.2
+rbenv install 2.7.2
+
+# Check the version
+ruby -v
+
+# Install bundler
+gem install bundler -v 2.4.22
+
+
+# Proceed with 'bundle' command
+bundle
+```
 ## Deployment
 
 The app is hosted on S3, with Cloudfront for a CDN.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "parcel index.html --port 3000",
     "indexer:transformDataset": "bundle exec ruby scripts/indexer/transform_dataset.rb",
     "indexer:importToTypesense": "bundle exec ruby scripts/indexer/index.rb",
-    "typesenseServer": "docker run -i -p 8108:8108 -v`pwd`/typesense-server-data/:/data typesense/typesense:0.17.0 --data-dir /data --api-key=xyz --listen-port 8108 --enable-cors",
+    "typesenseServer": "docker run -i -p 8108:8108 -v`pwd`/typesense-server-data/:/data typesense/typesense:28.0 --data-dir /data --api-key=xyz --listen-port 8108 --enable-cors",
     "build": "parcel build index.html",
     "deploy": "rm -rf build && yarn build && aws s3 cp --recursive ./dist s3://recipe-search.typesense.org/ --profile typesense && yarn clearCDNCache",
     "clearCDNCache": "aws cloudfront create-invalidation --distribution-id E11CLJMGS6TH1U --paths \"/*\" --profile typesense",


### PR DESCRIPTION
## Change Summary
- How to install ruby to run dataset transformation and indexing
- Clearer instructions about local running
- Update on local typesense server to 28.0 (newer JS instantsearch don't work with version 0.17)
- Fixed collection name in indexer.rb so it reflects the same on .dev.development

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
